### PR TITLE
Didn't initialize the random wallet quite right.

### DIFF
--- a/bitmerchant/wallet/bip32.py
+++ b/bitmerchant/wallet/bip32.py
@@ -2,9 +2,9 @@ from binascii import hexlify
 from binascii import unhexlify
 from hashlib import sha512
 import hmac
-import random
 
 import base58
+from Crypto.Random import random
 from ecdsa import SECP256k1
 from ecdsa.ecdsa import Public_key as _ECDSA_Public_key
 import six
@@ -548,8 +548,7 @@ class Wallet(object):
     @classmethod
     def new_random_wallet(cls, network=BitcoinMainNet):
         """Generate a new wallet using a randomly generated 512 bit seed."""
-        rand = random.SystemRandom()
-        random_seed = rand.getrandbits(512)
+        random_seed = random.getrandbits(512)
         random_hex_bytes = long_to_hex(random_seed, 128)  # 64 Bytes
         return cls.from_master_secret(random_hex_bytes, network=network)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 base58==0.2.1
 ecdsa==0.10
+pycrypto==2.6.1
 six==1.5.2


### PR DESCRIPTION
First, the long_to_hex call was wrong - it put 192 Bytes of zeros before
the 64 byte random key. I fixed this to only use the randomly generated
part.

Second, on the advice of @cyc I am using random.SystemRandom() instead
of just random. The reason is right there in the python docs:

http://docs.python.org/2/library/random.html:
"The pseudo-random generators of this module should not be used for
security purposes. Use os.urandom() or SystemRandom if you require a
cryptographically secure pseudo-random number generator."
# yolocrypto

Thanks @cyc for the suggestion (see https://github.com/sbuss/bitmerchant/commit/d99661aaf0e3865c5d18753ec665a43f1b8602ab#commitcomment-5493500)
